### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,7 @@ on:
 jobs:
   pypi-publish:
     name: Upload release to PyPi
-    runs-on: ${{ matrix.os }}
-    strategy:
-        matrix:
-            os: [ubuntu-latest, windows-latest, macos-latest]
-    
+    runs-on: ubuntu-latest
     permissions:
         id-token: write
     

--- a/src/fast_bioservices/__init__.py
+++ b/src/fast_bioservices/__init__.py
@@ -1,5 +1,5 @@
 __all__ = ["BiGG", "BioDBNet", "Input", "Output", "Taxon"]
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __description__ = "A fast way to access and convert biological information"
 
 from fast_bioservices.bigg.bigg import BiGG


### PR DESCRIPTION
PDM automatically builds using the `any` architecture, allowing ubuntu/windows/mac to install the package. Explicitly building for multiple platforms is not required