### PR TITLE
Return a taxon class from an integer

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,21 +1,21 @@
 name: Testing
 on:
-    pull_request:
-        branches:
-            - main
-        types: [opened, reopened, edited, synchronize]
+  pull_request:
+    branches:
+      - main
+    types: [ opened, reopened, edited, synchronize ]
 
 concurrency:
-    group: testing-${{ github.ref }}
-    cancel-in-progress: true
+  group: testing-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     name: Test with Python ${{ matrix.python-version }} on ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest, windows-latest]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
 
     env:
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-            fetch-depth: 0
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
 
     env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ dependencies = [
     "appdirs>=1.4.4",
     "pandas>=2.0.0",
     "loguru>=0.7.2",
+    "httpx>=0.27.2",
+    "hishel>=0.0.33",
 ]
 
 [build-system]
@@ -22,3 +24,6 @@ dev-dependencies = ["pytest>=8.3.2"]
 
 [tool.ruff]
 line-length = 150
+
+[tool.ruff.lint]
+ignore = ["F401"]

--- a/src/fast_bioservices/bigg/bigg.py
+++ b/src/fast_bioservices/bigg/bigg.py
@@ -26,13 +26,11 @@ class BiGG(BaseModel, FastHTTP):
 
     def version(self, temp_disable_cache: bool = False) -> Mapping[Any, Any]:
         response = self._get(f"{self.url}/database_version", temp_disable_cache=temp_disable_cache)[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def models(self, temp_disable_cache: bool = False) -> Mapping[Any, Any]:
         response = self._get(f"{self.url}/models", temp_disable_cache=temp_disable_cache)[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def model_details(
         self,
@@ -40,8 +38,7 @@ class BiGG(BaseModel, FastHTTP):
         temp_disable_cache: bool = False,
     ) -> Mapping[Any, Any]:
         response = self._get(f"{self.url}/models/{model_id}", temp_disable_cache=temp_disable_cache)[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def json(
         self,
@@ -49,8 +46,7 @@ class BiGG(BaseModel, FastHTTP):
         temp_disable_cache: bool = False,
     ) -> Mapping[Any, Any]:
         response = self._get(f"{self.url}/models/{model_id}/download", temp_disable_cache=temp_disable_cache)[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def download(
         self,
@@ -78,8 +74,7 @@ class BiGG(BaseModel, FastHTTP):
         temp_disable_cache: bool = False,
     ) -> Mapping[Any, Any]:
         response = self._get(f"{self.url}/models/{model_id}/reactions", temp_disable_cache=temp_disable_cache)[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def model_reaction_details(
         self,
@@ -91,8 +86,7 @@ class BiGG(BaseModel, FastHTTP):
             f"{self.url}/models/{model_id}/reactions/{reaction_id}",
             temp_disable_cache=temp_disable_cache,
         )[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def model_metabolites(
         self,
@@ -103,8 +97,7 @@ class BiGG(BaseModel, FastHTTP):
             f"{self.url}/models/{model_id}/metabolites",
             temp_disable_cache=temp_disable_cache,
         )[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def model_metabolite_details(
         self,
@@ -116,8 +109,7 @@ class BiGG(BaseModel, FastHTTP):
             f"{self.url}/models/{model_id}/metabolites/{metabolite_id}",
             temp_disable_cache=temp_disable_cache,
         )[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def model_genes(
         self,
@@ -125,8 +117,7 @@ class BiGG(BaseModel, FastHTTP):
         temp_disable_cache: bool = False,
     ) -> Mapping[Any, Any]:
         response = self._get(f"{self.url}/models/{model_id}/genes", temp_disable_cache=temp_disable_cache)[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def model_gene_details(
         self,
@@ -138,13 +129,11 @@ class BiGG(BaseModel, FastHTTP):
             f"{self.url}/models/{model_id}/genes/{gene_id}",
             temp_disable_cache=temp_disable_cache,
         )[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def universal_reactions(self, temp_disable_cache: bool = False) -> Mapping[Any, Any]:
         response = self._get(f"{self.url}/universal/reactions", temp_disable_cache=temp_disable_cache)[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def universal_reaction_details(
         self,
@@ -155,13 +144,11 @@ class BiGG(BaseModel, FastHTTP):
             f"{self.url}/universal/reactions/{reaction_id}",
             temp_disable_cache=temp_disable_cache,
         )[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def universal_metabolites(self, temp_disable_cache: bool = False) -> Mapping[Any, Any]:
         response = self._get(f"{self.url}/universal/metabolites", temp_disable_cache=temp_disable_cache)[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def universal_metabolite_details(
         self,
@@ -172,8 +159,7 @@ class BiGG(BaseModel, FastHTTP):
             f"{self.url}/universal/metabolites/{metabolite_id}",
             temp_disable_cache=temp_disable_cache,
         )[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)
 
     def search(
         self,
@@ -185,5 +171,4 @@ class BiGG(BaseModel, FastHTTP):
             f"{self.url}/search?query={query}&search_type={search_type}",
             temp_disable_cache=temp_disable_cache,
         )[0]
-        as_json = json.loads(response)
-        return as_json
+        return json.loads(response)

--- a/src/fast_bioservices/bigg/bigg.py
+++ b/src/fast_bioservices/bigg/bigg.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import json
-from typing import Any, Literal, Mapping, Optional
+from typing import Any, Literal, Mapping
 
 from fast_bioservices.base import BaseModel
 from fast_bioservices.fast_http import FastHTTP
@@ -54,7 +56,7 @@ class BiGG(BaseModel, FastHTTP):
         self,
         model_id: str,
         format: Literal["json", "xml", "mat", "json.gz", "xml.gz", "mat.gz"],
-        download_path: Optional[str] = None,
+        download_path: str | None = None,
         temp_disable_cache: bool = False,
     ) -> None:
         if download_path is None:

--- a/src/fast_bioservices/biodbnet/biodbnet.py
+++ b/src/fast_bioservices/biodbnet/biodbnet.py
@@ -138,7 +138,10 @@ class BioDBNet(BaseModel, FastHTTP):
         output_db: Union[Output, List[Output]],
         taxon: Union[Taxon, int] = Taxon.HOMO_SAPIENS,
     ) -> pd.DataFrame:
-        taxon_id = self._validate_taxon_id(taxon)[0]
+        taxon_id = self._validate_taxon_id(taxon)
+        if isinstance(taxon_id, list):
+            taxon_id = taxon_id[0]
+
         if not self._are_nodes_valid(input_db, output_db):
             out_db: list = [output_db] if not isinstance(output_db, list) else output_db
             raise ValueError(

--- a/src/fast_bioservices/biodbnet/biodbnet.py
+++ b/src/fast_bioservices/biodbnet/biodbnet.py
@@ -74,27 +74,27 @@ class BioDBNet(BaseModel, FastHTTP):
         for t in taxon_list:
             logger.debug(f"Validating taxon ID '{t}'")
             taxon_url: str = f"https://www.ncbi.nlm.nih.gov/taxonomy/?term={t}"
-            if "No items found." in str(self._get(taxon_url, temp_disable_cache=True, temp_disable_progress=True)[0]):
+            if "No items found." in str(self._get(taxon_url, temp_disable_cache=True, log_on_complete=False)[0]):
                 raise ValueError(f"Unable to find taxon '{t}'")
-        logger.debug(f"Taxon IDs are valid: {','.join([str(i) for i in taxon_list])}")
+        logger.debug(f"Taxon IDs are valid: '{','.join([str(i) for i in taxon_list])}'")
 
         return taxon_list
 
     def getDirectOutputsForInput(self, input: Union[Input, Output]) -> List[str]:
         url = f"{self.url}?method=getdirectoutputsforinput&input={input.value.replace(' ', '').lower()}&directOutput=1"
-        outputs = self._get(url, temp_disable_cache=True, temp_disable_progress=True)[0]
+        outputs = self._get(url, temp_disable_cache=True, log_on_complete=False)[0]
         as_json = json.loads(outputs)
         return as_json["output"]
 
     def getInputs(self) -> List[str]:
         url = f"{self.url}?method=getinputs"
-        inputs = self._get(url, temp_disable_cache=True, temp_disable_progress=True)[0]
+        inputs = self._get(url, temp_disable_cache=True, log_on_complete=False)[0]
         as_json = json.loads(inputs)
         return as_json["input"]
 
     def getOutputsForInput(self, input: Union[Input, Output]) -> List[str]:
         url = f"{self.url}?method=getoutputsforinput&input={input.value.replace(' ', '').lower()}"
-        valid_outputs = json.loads(self._get(url, temp_disable_cache=True, temp_disable_progress=True)[0].decode())
+        valid_outputs = json.loads(self._get(url, temp_disable_cache=True, log_on_complete=False)[0].decode())
         return valid_outputs["output"]
 
     def getAllPathways(
@@ -358,6 +358,10 @@ if __name__ == "__main__":
     logger.remove()
     logger.add(sys.stderr, level="TRACE")
 
-    biodbnet = BioDBNet(cache=False)
-    result = biodbnet.dbFind(input_values=gene_ids(), output_db=Output.GENE_SYMBOL)
+    biodbnet = BioDBNet(cache=True)
+    result = biodbnet.db2db(
+        input_values=[str(i) for i in range(65000)],
+        input_db=Input.GENE_ID,
+        output_db=Output.GENE_SYMBOL,
+    )
     print(result)

--- a/src/fast_bioservices/biodbnet/biodbnet.py
+++ b/src/fast_bioservices/biodbnet/biodbnet.py
@@ -60,7 +60,7 @@ class BioDBNet(BaseModel, FastHTTP):
         self,
         taxon: int | str | Taxon | list[int | str | Taxon],
     ) -> List[int]:
-        taxon_list: list[int | str] = []
+        taxon_list: list[int] = []
 
         if isinstance(taxon, Taxon):
             taxon_list.append(taxon.value)
@@ -83,9 +83,10 @@ class BioDBNet(BaseModel, FastHTTP):
 
         for t in taxon_list:
             logger.debug(f"Validating taxon ID '{t}'")
-            taxon_url: str = f"https://www.ncbi.nlm.nih.gov/taxonomy/?term={t}"
-            if "No items found." in str(self._get(taxon_url, temp_disable_cache=True, log_on_complete=False)[0]):
-                raise ValueError(f"Unable to find taxon '{t}'")
+            if t not in Taxon.member_values():  # All items in the 'Taxon' enum are valid, only need to check items not in enum
+                taxon_url: str = f"https://www.ncbi.nlm.nih.gov/taxonomy/?term={t}"
+                if "No items found." in str(self._get(taxon_url, temp_disable_cache=True, log_on_complete=False)[0]):
+                    raise ValueError(f"Unable to find taxon '{t}'")
         logger.debug(f"Taxon IDs are valid: '{','.join([str(i) for i in taxon_list])}'")
 
         return taxon_list

--- a/src/fast_bioservices/biodbnet/biodbnet.py
+++ b/src/fast_bioservices/biodbnet/biodbnet.py
@@ -67,7 +67,7 @@ class BioDBNet(BaseModel, FastHTTP):
         elif isinstance(taxon, int):
             taxon_list.append(taxon)
         elif isinstance(taxon, str):
-            logger.warning(f"The provided taxon ID ('{taxon}') was a string, attempting to map it to a known integer value...")
+            logger.warning(f"The provided taxon ID ('{taxon}') is a string, attempting to map it to a known integer value...")
             taxon_list.append(Taxon.string_to_obj(taxon).value)
         elif isinstance(taxon, list):
             for t in taxon:
@@ -161,16 +161,19 @@ class BioDBNet(BaseModel, FastHTTP):
             output_db_value = output_db.value.lower().replace(" ", "")
         else:
             output_db_value = ",".join([o.value.lower().replace(" ", "") for o in output_db])
-        logger.debug(f"Got an input database with a value of '{input_db.value}'")
+        logger.debug(f"Got an input database with a value of '{input_db.value.lower().replace(' ', '')}'")
         logger.debug(f"Got {len(output_db_value.split(','))} output databases with values of: '{output_db_value}'")
 
         urls: list[str] = []
         for i in range(0, len(input_values), self._chunk_size):
-            urls.append(self.url + "?method=db2db&format=row")
-            urls[-1] += f"&input={input_db.value.lower().replace(' ', '')}"
-            urls[-1] += f"&outputs={output_db_value}"
-            urls[-1] += f"&inputValues={','.join(input_values[i: i + self._chunk_size])}"
-            urls[-1] += f"&taxonId={taxon_id}"
+            urls.append(
+                f"{self.url}?method=db2db"
+                f"&format=row"
+                f"&input={input_db.value.lower().replace(' ', '')}"
+                f"&outputs={output_db_value}"
+                f"&inputValues={','.join(input_values[i: i + self._chunk_size])}"
+                f"&taxonId={taxon_id}"
+            )
 
         responses: List[bytes] = self._get(urls=urls)
         df = pd.DataFrame()

--- a/src/fast_bioservices/biodbnet/nodes.py
+++ b/src/fast_bioservices/biodbnet/nodes.py
@@ -1,4 +1,4 @@
-from enum import Enum, member
+from enum import Enum
 
 from loguru import logger
 

--- a/src/fast_bioservices/biodbnet/nodes.py
+++ b/src/fast_bioservices/biodbnet/nodes.py
@@ -34,7 +34,7 @@ class Taxon(Enum):
     @classmethod
     def string_to_obj(cls, n: str) -> "Taxon":
         if n.lower() in ("human", "homo sapien", "homo sapiens"):
-            logger.info(f"Mapped '{n}' to '9606")
+            logger.info(f"Mapped '{n}' to '9606'")
             return Taxon.HOMO_SAPIENS
         elif n.lower() in ("mouse", "mus musculus"):
             logger.info(f"Mapped '{n}' to '10090'")

--- a/src/fast_bioservices/biodbnet/nodes.py
+++ b/src/fast_bioservices/biodbnet/nodes.py
@@ -34,10 +34,10 @@ class Taxon(Enum):
     @classmethod
     def string_to_obj(cls, n: str) -> "Taxon":
         if n.lower() in ("human", "homo sapien", "homo sapiens"):
-            logger.info(f"Mapped '{n}' to '9606'")
+            logger.info(f"Mapped '{n}' to NCBI taxonomy ID '9606'")
             return Taxon.HOMO_SAPIENS
         elif n.lower() in ("mouse", "mus musculus"):
-            logger.info(f"Mapped '{n}' to '10090'")
+            logger.info(f"Mapped '{n}' to NCBI taxonomy ID '10090'")
             return Taxon.MUS_MUSCULUS
         else:
             raise ValueError(f"Unknown taxon '{n}'")

--- a/src/fast_bioservices/biodbnet/nodes.py
+++ b/src/fast_bioservices/biodbnet/nodes.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class Taxon(int, Enum):
+class Taxon(Enum):
     ARABIDOPSIS_THALIANA = 3702
     BOS_TAURUS = 9913
     CAENORHABDITIS_ELEGANS = 6239
@@ -31,7 +31,7 @@ class Taxon(int, Enum):
         return cls(n)
 
 
-class Input(str, Enum):
+class Input(Enum):
     """
     These are valid input database types for the BioDBNet API.
     """
@@ -102,7 +102,7 @@ class Input(str, Enum):
     UNISTS_ID = "UniSTS ID"
 
 
-class Output(str, Enum):
+class Output(Enum):
     """
     These are valid output database types for the BioDBNet API.
     """

--- a/src/fast_bioservices/biodbnet/nodes.py
+++ b/src/fast_bioservices/biodbnet/nodes.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from loguru import logger
 
 
 class Taxon(Enum):
@@ -29,6 +30,17 @@ class Taxon(Enum):
         if n not in cls.__members__:
             raise ValueError(f"Invalid taxon id: {n}")
         return cls(n)
+
+    @classmethod
+    def string_to_obj(cls, n: str) -> "Taxon":
+        if n.lower() in ("human", "homo sapien", "homo sapiens"):
+            logger.info(f"Mapped '{n}' to '9606")
+            return Taxon.HOMO_SAPIENS
+        elif n.lower() in ("mouse", "mus musculus"):
+            logger.info(f"Mapped '{n}' to '10090'")
+            return Taxon.MUS_MUSCULUS
+        else:
+            raise ValueError(f"Unknown taxon '{n}'")
 
 
 class Input(Enum):

--- a/src/fast_bioservices/biodbnet/nodes.py
+++ b/src/fast_bioservices/biodbnet/nodes.py
@@ -26,6 +26,8 @@ class Taxon(int, Enum):
 
     @classmethod
     def from_int(cls, n: int) -> "Taxon":
+        if n not in cls.__members__:
+            raise ValueError(f"Invalid taxon id: {n}")
         return cls(n)
 
 

--- a/src/fast_bioservices/biodbnet/nodes.py
+++ b/src/fast_bioservices/biodbnet/nodes.py
@@ -1,4 +1,5 @@
-from enum import Enum
+from enum import Enum, member
+
 from loguru import logger
 
 
@@ -13,6 +14,7 @@ class Taxon(Enum):
     ESCHERICHIA_COLI = 562
     HEPACIVIRUS_HOMINIS = 3052230
     HOMO_SAPIENS = 9606
+    MACACA_MULATTA = 9544
     MUS_MUSCULUS = 10090
     MYCOPLASMOIDES_PNEUMONIAE = 2104
     ORYZA_SATIVA = 4530
@@ -27,7 +29,8 @@ class Taxon(Enum):
 
     @classmethod
     def member_values(cls) -> list[int]:
-        return list(cls.__members__.values())
+        member_values: list[Taxon] = list(cls.__members__.values())
+        return [i.value for i in member_values]
 
     @classmethod
     def from_int(cls, n: int) -> "Taxon":

--- a/src/fast_bioservices/biodbnet/nodes.py
+++ b/src/fast_bioservices/biodbnet/nodes.py
@@ -24,6 +24,10 @@ class Taxon(int, Enum):
     XENOPUS_LAEVIS = 8355
     ZEA_MAYS = 4577
 
+    @classmethod
+    def from_int(cls, n: int) -> "Taxon":
+        return cls(n)
+
 
 class Input(str, Enum):
     """

--- a/src/fast_bioservices/biodbnet/nodes.py
+++ b/src/fast_bioservices/biodbnet/nodes.py
@@ -40,10 +40,10 @@ class Taxon(Enum):
 
     @classmethod
     def string_to_obj(cls, n: str) -> "Taxon":
-        if n.lower() in ("human", "homo sapien", "homo sapiens"):
+        if n.lower() in {"human", "homo sapien", "homo sapiens"}:
             logger.info(f"Mapped '{n}' to NCBI taxonomy ID '9606'")
             return Taxon.HOMO_SAPIENS
-        elif n.lower() in ("mouse", "mus musculus"):
+        elif n.lower() in {"mouse", "mus musculus"}:
             logger.info(f"Mapped '{n}' to NCBI taxonomy ID '10090'")
             return Taxon.MUS_MUSCULUS
         else:

--- a/src/fast_bioservices/biodbnet/nodes.py
+++ b/src/fast_bioservices/biodbnet/nodes.py
@@ -26,6 +26,10 @@ class Taxon(Enum):
     ZEA_MAYS = 4577
 
     @classmethod
+    def member_values(cls) -> list[int]:
+        return list(cls.__members__.values())
+
+    @classmethod
     def from_int(cls, n: int) -> "Taxon":
         if n not in cls.__members__:
             raise ValueError(f"Invalid taxon id: {n}")

--- a/src/fast_bioservices/ensembl/comparative_genomics.py
+++ b/src/fast_bioservices/ensembl/comparative_genomics.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 import json
-from typing import List, Literal, Optional, Union
+from typing import List, Literal
 
 from fast_bioservices.ensembl.ensembl import Ensembl
 from fast_bioservices.settings import default_workers
@@ -72,7 +74,7 @@ class GetHomology(Ensembl):
     def by_species_with_symbol_or_id(
         self,
         reference_species: str,
-        ensembl_id_or_symbol: Union[str, List[str]],
+        ensembl_id_or_symbol: str | List[str],
         aligned: bool = True,
         cigar_line: bool = True,
         compara: str = "vertebrates",
@@ -80,7 +82,7 @@ class GetHomology(Ensembl):
         format: Literal["full", "condensed"] = "full",
         sequence: Literal["none", "cdna", "protein"] = "protein",
         target_species: str = "",
-        target_taxon: Optional[int] = None,
+        target_taxon: int | None = None,
         type: Literal["orthologues", "paralogues", "projections", "all"] = "all",
     ) -> List[HomologyResult]:
         ensembl_id_or_symbol = [ensembl_id_or_symbol] if isinstance(ensembl_id_or_symbol, str) else ensembl_id_or_symbol

--- a/src/fast_bioservices/ensembl/cross_references.py
+++ b/src/fast_bioservices/ensembl/cross_references.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 import json
-from typing import List, Literal, Optional, Union
+from typing import List, Literal
 
 from fast_bioservices.ensembl.ensembl import Ensembl, Species
 from fast_bioservices.settings import default_workers
@@ -39,12 +41,12 @@ class CrossReference(Ensembl):
     def get_ensembl_from_external(
         self,
         species: str,
-        gene_symbols: Union[str, List[str]],
+        gene_symbols: str | List[str],
         db_type: Literal["core"] = "core",
-        external_db_filter: Optional[str] = None,
-        feature_filter: Optional[str] = None,
+        external_db_filter: str | None = None,
+        feature_filter: str | None = None,
     ):
-        validate_species: Optional[Species] = self._match_species(species)
+        validate_species: Species | None = self._match_species(species)
         assert validate_species is not None, f"Species {species} not found"
 
         gene_symbols = [gene_symbols] if isinstance(gene_symbols, str) else gene_symbols
@@ -66,12 +68,12 @@ class CrossReference(Ensembl):
 
     def get_external_from_ensembl(
         self,
-        ensembl_id: Union[str, List[str]],
+        ensembl_id: str | List[str],
         db_type: Literal["core"] = "core",
         all_levels: bool = False,
-        external_db_filter: Optional[str] = None,
-        feature_filter: Optional[str] = None,
-        species: Optional[str] = None,
+        external_db_filter: str | None = None,
+        feature_filter: str | None = None,
+        species: str | None = None,
     ) -> List[ExternalReference]:
         ensembl_id = [ensembl_id] if isinstance(ensembl_id, str) else ensembl_id
 

--- a/src/fast_bioservices/ensembl/ensembl.py
+++ b/src/fast_bioservices/ensembl/ensembl.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 import json
-from typing import List, Optional
+from typing import List
 
 from fast_bioservices.base import BaseModel
 from fast_bioservices.fast_http import FastHTTP
@@ -49,7 +51,7 @@ class Ensembl(BaseModel, FastHTTP):
             species.append(Species(**item))
         return species
 
-    def _match_species(self, species: str) -> Optional[Species]:
+    def _match_species(self, species: str) -> Species | None:
         """
         This function will make sure the user enters a valid species name
         It will do this by collecting all the species names from the Ensembl API

--- a/src/fast_bioservices/ensembl/ensembl.py
+++ b/src/fast_bioservices/ensembl/ensembl.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import json
+from dataclasses import dataclass
 from typing import List
 
 from fast_bioservices.base import BaseModel
@@ -43,12 +43,11 @@ class Ensembl(BaseModel, FastHTTP):
         return self._url
 
     def __get_species(self) -> List[Species]:
-        path = self._url + "/info/species"
+        path = f"{self._url}/info/species"
         response = self._get(path, headers={"Content-Type": "application/json"})
         species: list[Species] = []
         as_json = json.loads(response[0].decode())
-        for item in as_json["species"]:
-            species.append(Species(**item))
+        species.extend(Species(**item) for item in as_json["species"])
         return species
 
     def _match_species(self, species: str) -> Species | None:

--- a/src/fast_bioservices/fast_http.py
+++ b/src/fast_bioservices/fast_http.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import lzma
 import pickle
@@ -11,7 +13,7 @@ from abc import ABC
 from concurrent.futures import Future, ThreadPoolExecutor, wait
 from http.client import HTTPResponse
 from pathlib import Path
-from typing import List, Literal, Optional, Union
+from typing import List, Literal
 
 from loguru import logger
 
@@ -26,7 +28,7 @@ class FastHTTP(ABC):
         *,
         cache: bool,
         workers: int,
-        max_requests_per_second: Optional[int],
+        max_requests_per_second: int | None,
     ) -> None:
         self._max_requests_per_second: int = float("inf") if max_requests_per_second is None else max_requests_per_second
         self._maximum_allowed_workers: int = 5
@@ -67,7 +69,7 @@ class FastHTTP(ABC):
             pass
 
     @staticmethod
-    def _make_safe_url(urls: Union[str, List[str]]) -> List[str]:
+    def _make_safe_url(urls: str | List[str]) -> List[str]:
         # Safe characters from https://stackoverflow.com/questions/695438
         safe = "&$+,/:;=?@#"
         if isinstance(urls, str):
@@ -109,7 +111,7 @@ class FastHTTP(ABC):
 
         return content
 
-    def __get_from_cache(self, url: str, headers: dict, log_on_complete: bool) -> Optional[bytes]:
+    def __get_from_cache(self, url: str, headers: dict, log_on_complete: bool) -> bytes | None:
         cache_file = self._calculate_cache_key(url)
         if cache_file.exists():
             with lzma.open(cache_file) as cache_file:
@@ -125,8 +127,8 @@ class FastHTTP(ABC):
 
     def _get(
         self,
-        urls: Union[str, List[str]],
-        headers: Optional[dict] = None,
+        urls: str | List[str],
+        headers: dict | None = None,
         temp_disable_cache: bool = False,
         log_on_complete: bool = True,
     ) -> List[bytes]:

--- a/src/fast_bioservices/fast_http.py
+++ b/src/fast_bioservices/fast_http.py
@@ -34,9 +34,11 @@ class FastHTTP(ABC):
         self._workers: int = self._set_workers(workers)
 
         self._cache_dirpath: Path = cache_dir
-        self._requests_made: int = 0
+        self._non_cached_requests_made: int = 0
         self._last_request_time: float = 0
 
+        self._current_requests: int = 0
+        self._total_requests: int = 0
         self._thread_pool = ThreadPoolExecutor(max_workers=self._workers)
 
     def _set_workers(self, value: int) -> int:
@@ -72,33 +74,47 @@ class FastHTTP(ABC):
             return [urllib.parse.quote(urls, safe=safe)]
         return [urllib.parse.quote(url, safe=safe) for url in urls]
 
+    def _log_on_complete_callback(self, ending: str):
+        self._current_requests += 1
+        logger.debug(f"Finished {self._current_requests:>{len(str(self._total_requests))}} of {self._total_requests} ({ending})")
+
     def _calculate_cache_key(self, url: str) -> Path:
         cache_key = hashlib.md5(url.encode()).hexdigest()
         cache_file = Path(self._cache_dirpath, cache_key)
         return cache_file
 
-    def __get_without_cache(self, url: str, headers: dict) -> bytes:
+    def __get_without_cache(self, url: str, headers: dict, log_on_complete: bool) -> bytes:
         # Rate limiting
-        self._requests_made += 1
+        self._non_cached_requests_made += 1
         current_time = time.time()
         time_since_last_request = current_time - self._last_request_time
-        if self._requests_made > self._max_requests_per_second and time_since_last_request < 1:
+        if self._non_cached_requests_made > self._max_requests_per_second and time_since_last_request < 1:
             time.sleep(1 - time_since_last_request)
-            self._requests_made -= self._max_requests_per_second
+            self._non_cached_requests_made -= self._max_requests_per_second
         self._last_request_time = current_time
 
         request = urllib.request.Request(url, headers=headers)
-        response: HTTPResponse = urllib.request.urlopen(request)
+        try:
+            response: HTTPResponse = urllib.request.urlopen(request)
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return b""
+            raise e
+
         content: bytes = response.read()
         if self._use_cache:
             self._save_to_cache(url, content=content)
+        if log_on_complete:
+            self._log_on_complete_callback("without cache")
+
         return content
 
-    def __get_from_cache(self, url: str, headers: dict) -> Optional[bytes]:
+    def __get_from_cache(self, url: str, headers: dict, log_on_complete: bool) -> Optional[bytes]:
         cache_file = self._calculate_cache_key(url)
         if cache_file.exists():
-            logger.trace(f"Cache hit: {url}")
             with lzma.open(cache_file) as cache_file:
+                if log_on_complete:
+                    self._log_on_complete_callback("with cache")  # Only log when the cache file is found
                 return pickle.load(cache_file)
         return None
 
@@ -112,35 +128,35 @@ class FastHTTP(ABC):
         urls: Union[str, List[str]],
         headers: Optional[dict] = None,
         temp_disable_cache: bool = False,
-        temp_disable_progress: bool = False,
+        log_on_complete: bool = True,
     ) -> List[bytes]:
         headers = headers or {}
         urls = self._make_safe_url(urls)
+
+        self._current_requests = 0
+        self._total_requests = len(urls)
+
         callable_ = self.__get_from_cache if (self._use_cache and not temp_disable_cache) else self.__get_without_cache
 
         futures: list[Future[bytes]] = []
         url_mapping: dict[Future, str] = {}
         for url in urls:
-            future = self._thread_pool.submit(callable_, url=url, headers=headers)
+            future = self._thread_pool.submit(callable_, url=url, headers=headers, log_on_complete=log_on_complete)
             futures.append(future)
             url_mapping[future] = url
 
         responses: List[bytes] = []
-        finished_count: int = 0
         while futures:
             for future in wait(futures).done:
                 try:
                     result = future.result()
                     url = url_mapping[future]
                     if result is None:  # Cache miss
-                        new_future = self._thread_pool.submit(self.__get_without_cache, url=url, headers=headers)
+                        new_future = self._thread_pool.submit(self.__get_without_cache, url=url, headers=headers, log_on_complete=log_on_complete)
                         futures.append(new_future)
                         url_mapping[new_future] = url
                     else:  # Cache hit
                         responses.append(result)
-                        finished_count += 1
-                        if not temp_disable_progress:
-                            logger.debug(f"Finished {finished_count} of {len(urls)} tasks")
                 except Exception as e:
                     logger.error(f"Error in future: {e}")
                     raise e

--- a/src/fast_bioservices/fast_http.py
+++ b/src/fast_bioservices/fast_http.py
@@ -1,25 +1,101 @@
 from __future__ import annotations
 
-import hashlib
-import lzma
-import pickle
+import sys
 import time
-import urllib
-import urllib.error
 import urllib.parse
-import urllib.request
-import urllib.response
 from abc import ABC
-from concurrent.futures import Future, ThreadPoolExecutor, wait
-from http.client import HTTPResponse
+from collections import deque
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import List, Literal
+from typing import List
 
+import hishel
+import httpcore
+import httpx
+from hishel._utils import generate_key
+from httpx import Request, Response
 from loguru import logger
 
 from fast_bioservices.settings import cache_dir
 
-Method = Literal["GET"]
+NO_CACHE: str = "no-store, max-age=0"
+MAX_CACHE: str = f"max-age={sys.maxsize}"
+
+
+def _key_generator(request: httpx.Request | httpcore.Request, body: bytes = b"") -> str:
+    if isinstance(request, httpx.Request):
+        request = httpcore.Request(
+            method=str(request.method), url=str(request.url), headers=request.headers, content=request.content, extensions=request.extensions
+        )
+    key = generate_key(request, body)
+    method = request.method.decode("ascii") if isinstance(request.method, bytes) else request.method
+    host = request.url.host.decode("ascii") if isinstance(request.url.host, bytes) else request.url.host
+    return f"{method}|{host}|{key}"
+
+
+def _get_cache_path(request: httpx.Request) -> Path:
+    return Path(cache_dir, _key_generator(request))
+
+
+class RateLimit(httpx.BaseTransport):
+    """
+    Implement rate limiting on httpx transports
+    """
+
+    def __init__(self, transport: httpx.BaseTransport, rate: int | float, period: int | float, use_cache: bool):
+        self.transport = transport
+        self.rate = rate  # Requests per second
+        self.period = period  # Time period in seconds
+        self.use_cache = use_cache
+        self.last_reset = time.time()
+        self.requests_in_period = deque(maxlen=rate)
+        self._cache_storage: hishel.FileStorage | None = None
+
+    @property
+    def cache_storage(self):
+        return self._cache_storage
+
+    @cache_storage.setter
+    def cache_storage(self, storage):
+        self._cache_storage = storage
+
+    def _build_from_cache(self, request: Request) -> Response | None:
+        cache_path: Path = _get_cache_path(request)
+        if self.use_cache and request.headers["Cache-Control"] != NO_CACHE and cache_path.exists():
+            cached_response = self._cache_storage.retrieve(cache_path.stem)
+            if isinstance(cached_response, httpcore.Response):
+                return httpx.Response(
+                    status_code=cached_response.status,
+                    headers=cached_response.headers,
+                    content=cached_response.content,
+                    extensions=cached_response.extensions,
+                )
+            return self.transport.handle_request(request)
+        return None
+
+    def handle_request(self, request: Request) -> Response:
+        # Exit early if we are using cache and the key exists
+        is_cached = self._build_from_cache(request)
+        if is_cached is not None:
+            return is_cached
+
+        now = time.time()
+        if now - self.last_reset >= self.period:
+            self.last_reset = now
+            self.requests_in_period.clear()
+
+        while len(self.requests_in_period) >= self.rate:
+            time.sleep(1 / self.rate)
+            logger.debug(f"Sleeping for {1 / self.rate} seconds")
+            now = time.time()
+            if now - self.last_reset >= self.period:
+                self.last_reset = now
+                self.requests_in_period.clear()
+                break
+
+        self.requests_in_period.append(now)
+        response = self.transport.handle_request(request)
+        return response
 
 
 class FastHTTP(ABC):
@@ -30,14 +106,17 @@ class FastHTTP(ABC):
         workers: int,
         max_requests_per_second: int | None,
     ) -> None:
-        self._max_requests_per_second: int = float("inf") if max_requests_per_second is None else max_requests_per_second
         self._maximum_allowed_workers: int = 5
         self._use_cache: bool = cache
         self._workers: int = self._set_workers(workers)
-
-        self._cache_dirpath: Path = cache_dir
-        self._non_cached_requests_made: int = 0
-        self._last_request_time: float = 0
+        self._transport = RateLimit(transport=httpx.HTTPTransport(), rate=max_requests_per_second, period=1, use_cache=self._use_cache)
+        if self._use_cache:
+            self._storage = hishel.FileStorage(base_path=cache_dir, ttl=sys.maxsize)
+            self._controller = hishel.Controller(key_generator=_key_generator, allow_stale=True, force_cache=True)
+            self._client: hishel.CacheClient = hishel.CacheClient(storage=self._storage, controller=self._controller, transport=self._transport)
+            self._transport.cache_storage = self._storage
+        else:
+            self._client: httpx.Client = httpx.Client(transport=self._transport)
 
         self._current_requests: int = 0
         self._total_requests: int = 0
@@ -80,59 +159,28 @@ class FastHTTP(ABC):
         self._current_requests += 1
         logger.debug(f"Finished {self._current_requests:>{len(str(self._total_requests))}} of {self._total_requests} ({ending})")
 
-    def _calculate_cache_key(self, url: str) -> Path:
-        cache_key = hashlib.md5(url.encode()).hexdigest()
-        cache_file = Path(self._cache_dirpath, cache_key)
-        return cache_file
-
-    def __get_without_cache(self, url: str, headers: dict, log_on_complete: bool) -> bytes:
-        # Rate limiting
-        self._non_cached_requests_made += 1
-        current_time = time.time()
-        time_since_last_request = current_time - self._last_request_time
-        if self._non_cached_requests_made > self._max_requests_per_second and time_since_last_request < 1:
-            time.sleep(1 - time_since_last_request)
-            self._non_cached_requests_made -= self._max_requests_per_second
-        self._last_request_time = current_time
-
-        request = urllib.request.Request(url, headers=headers)
+    def _do_get(self, url: str, headers: dict, extensions: dict, log_on_complete: bool) -> bytes:
         try:
-            response: HTTPResponse = urllib.request.urlopen(request)
-        except urllib.error.HTTPError as e:
-            if e.code == 404:
-                return b""
+            with self._transport:
+                response: httpx.Response = self._client.get(url, headers=headers, timeout=60, extensions=extensions)
+        except httpx.ReadTimeout as e:
+            logger.critical(f"Read timeout error on url: {url}")
+            raise e
+        except httpx.ConnectTimeout as e:
+            logger.critical(f"Connect timeout error on url: {url}")
+            raise e
+        except httpx.ConnectError as e:
+            logger.critical(f"Connect error on url: {url}")
             raise e
 
-        content: bytes = response.read()
-        if self._use_cache:
-            self._save_to_cache(url, content=content)
         if log_on_complete:
-            self._log_on_complete_callback("without cache")
-
-        return content
-
-    def __get_from_cache(self, url: str, headers: dict, log_on_complete: bool) -> bytes | None:
-        cache_file = self._calculate_cache_key(url)
-        if cache_file.exists():
-            try:
-                with lzma.open(cache_file) as cache_file:
-                    content = pickle.load(cache_file)
-                if log_on_complete:
+            if "from_cache" in response.extensions.keys():
+                if response.extensions["from_cache"]:
                     self._log_on_complete_callback("with cache")
-                return content
-            except (pickle.UnpicklingError, lzma.LZMAError) as e:
-                logger.warning(f"Error loading from cache: {e}")
-                cache_file.unlink(missing_ok=True)
-        return None
+                else:
+                    self._log_on_complete_callback("without cache")
 
-    def _save_to_cache(self, url: str, content: bytes) -> None:
-        cache_filepath = self._calculate_cache_key(url)
-        data = pickle.dumps(content)
-        try:
-            with lzma.open(cache_filepath, "wb") as o_stream:
-                o_stream.write(data)
-        except (pickle.PickleError, lzma.LZMAError) as e:
-            logger.warning(f"Error saving to cache; attempted to save to {cache_filepath}: {e}")
+        return response.content
 
     def _get(
         self,
@@ -140,43 +188,21 @@ class FastHTTP(ABC):
         headers: dict | None = None,
         temp_disable_cache: bool = False,
         log_on_complete: bool = True,
+        extensions: dict | None = None,
     ) -> List[bytes]:
-        headers = headers or {}
         urls = self._make_safe_url(urls)
-
         self._current_requests = 0
         self._total_requests = len(urls)
 
-        callable_ = self.__get_from_cache if (self._use_cache and not temp_disable_cache) else self.__get_without_cache
+        headers = headers or {}
+        headers["Cache-Control"] = NO_CACHE if temp_disable_cache else MAX_CACHE
 
         futures: list[Future[bytes]] = []
         url_mapping: dict[Future, str] = {}
         for url in urls:
-            future = self._thread_pool.submit(callable_, url=url, headers=headers, log_on_complete=log_on_complete)
+            future = self._thread_pool.submit(self._do_get, url=url, headers=headers, extensions=extensions, log_on_complete=log_on_complete)
             futures.append(future)
             url_mapping[future] = url
 
-        responses: List[bytes] = []
-        while futures:
-            for future in wait(futures).done:
-                url = ""
-                try:
-                    result = future.result()
-                    url = url_mapping[future]
-                    if result is None:  # Cache miss
-                        new_future = self._thread_pool.submit(self.__get_without_cache, url=url, headers=headers, log_on_complete=log_on_complete)
-                        futures.append(new_future)
-                        url_mapping[new_future] = url
-                    else:  # Cache hit
-                        responses.append(result)
-                except Exception as e:
-                    logger.error(f"Error in future: {e} (url: {url})")
-                    raise e
-                finally:
-                    futures.remove(future)
-
+        responses: List[bytes] = [f.result() for f in as_completed(futures)]
         return responses
-
-
-if __name__ == "__main__":
-    http = FastHTTP(cache=True, workers=2, max_requests_per_second=10)

--- a/src/fast_bioservices/fast_http.py
+++ b/src/fast_bioservices/fast_http.py
@@ -159,6 +159,7 @@ class FastHTTP(ABC):
         responses: List[bytes] = []
         while futures:
             for future in wait(futures).done:
+                url = ""
                 try:
                     result = future.result()
                     url = url_mapping[future]
@@ -169,7 +170,7 @@ class FastHTTP(ABC):
                     else:  # Cache hit
                         responses.append(result)
                 except Exception as e:
-                    logger.error(f"Error in future: {e}")
+                    logger.error(f"Error in future: {e} (url: {url})")
                     raise e
                 finally:
                     futures.remove(future)

--- a/src/fast_bioservices/utils.py
+++ b/src/fast_bioservices/utils.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from difflib import SequenceMatcher
-from typing import List, Union
+from typing import List
 
 
 def flatten(lists: list) -> list:
@@ -12,7 +14,7 @@ def flatten(lists: list) -> list:
     return data
 
 
-def fuzzy_search(query: str, possibilities: Union[str, List[str]]) -> float:
+def fuzzy_search(query: str, possibilities: str | List[str]) -> float:
     matcher = SequenceMatcher(isjunk=None, a=query)
     if isinstance(possibilities, str):
         possibilities = [possibilities]

--- a/uv.lock
+++ b/uv.lock
@@ -7,12 +7,36 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.6.2.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/09/45b9b7a6d4e45c6bcb5bf61d19e3ab87df68e0601fa8c5293de3542546cc/anyio-4.6.2.post1.tar.gz", hash = "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c", size = 173422 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/f5/f2b75d2fc6f1a260f340f0e7c6a060f4dd2961cc16884ed851b0d18da06a/anyio-4.6.2.post1-py3-none-any.whl", hash = "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d", size = 90377 },
+]
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566 },
+]
+
+[[package]]
+name = "certifi"
+version = "2024.8.30"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9", size = 168507 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8", size = 167321 },
 ]
 
 [[package]]
@@ -35,10 +59,12 @@ wheels = [
 
 [[package]]
 name = "fast-bioservices"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },
+    { name = "hishel" },
+    { name = "httpx" },
     { name = "loguru" },
     { name = "pandas" },
 ]
@@ -51,12 +77,74 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "appdirs", specifier = ">=1.4.4" },
+    { name = "hishel", specifier = ">=0.0.33" },
+    { name = "httpx", specifier = ">=0.27.2" },
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "pandas", specifier = ">=2.0.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.3.2" }]
+
+[[package]]
+name = "h11"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259 },
+]
+
+[[package]]
+name = "hishel"
+version = "0.0.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cf/d4414a62b77d1f3f58a0d812be20efe4a647fc1e103cec7c9ac559efe576/hishel-0.0.33.tar.gz", hash = "sha256:ab5b2661d5e2252f305fd0fb20e8c76bfab3ea73458f20f2591c53c37b270089", size = 35331 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/3e/0ca767da4715abad09eda4ffcc3c8b69684cab271a055d856a424c9f5f1d/hishel-0.0.33-py3-none-any.whl", hash = "sha256:6e6c6cdaf432ff4c4981e7792ef7d1fa4c8ede58b9dbbcefb9ab3fc9770f2a07", size = 41654 },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/44/ed0fa6a17845fb033bd885c03e842f08c1b9406c86a2e60ac1ae1b9206a6/httpcore-1.0.6.tar.gz", hash = "sha256:73f6dbd6eb8c21bbf7ef8efad555481853f5f6acdeaff1edb0694289269ee17f", size = 85180 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/89/b161908e2f51be56568184aeb4a880fd287178d176fd1c860d2217f41106/httpcore-1.0.6-py3-none-any.whl", hash = "sha256:27b59625743b85577a8c0e10e55b50b5368a4f2cfe8cc7bcfa9cf00829c2682f", size = 78011 },
+]
+
+[[package]]
+name = "httpx"
+version = "0.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/82/08f8c936781f67d9e6b9eeb8a0c8b4e406136ea4c3d1f89a5db71d42e0e6/httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2", size = 144189 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/95/9377bcb415797e44274b51d46e3249eba641711cf3348050f76ee7b15ffc/httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0", size = 76395 },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+]
 
 [[package]]
 name = "iniconfig"
@@ -240,12 +328,30 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f", size = 15164 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc", size = 12757 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Refactor the FastHTTP class to implement rate limiting and caching using a new RateLimit class. Introduce a new Taxon class with methods for converting from integer and string representations. Update type annotations to use the modern '|' syntax for type unions. Enhance the CI configuration to test against Python 3.13.

New Features:
- Introduce a new Taxon class with methods to convert from integer and string representations.

Enhancements:
- Refactor the FastHTTP class to use a new RateLimit class for handling rate limiting and caching.
- Update type annotations across the codebase to use the new '|' syntax for type unions, improving readability and modernizing the code.

CI:
- Update the CI configuration to include testing for Python 3.13.