### PR TITLE
Fix BioThings MyGene `field` parameter

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 line-length = 120
 extend-include = ["docs/**/*.py", "tests/**/*.py"]
-exclude = ["__init__.py"]
+exclude = ["__init__.py", "main/COMO.ipynb"]
 
 [format]
 quote-style = "double"

--- a/src/fast_bioservices/biothings/mygene.py
+++ b/src/fast_bioservices/biothings/mygene.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from typing import NamedTuple
 
+from loguru import logger
+
 from fast_bioservices.biothings import BioThings
 from fast_bioservices.common import Taxon, validate_taxon_id
 
@@ -64,10 +66,13 @@ class MyGene(BioThings):
         """
         if ensembl_only and entrez_only:
             raise ValueError("Cannot specify both `ensembl_only` and `entrez_only` as True")
+        if fields == "":
+            logger.warning("Parameter 'fields' cannot be empty, using default of 'all'")
+            fields = ["all"]
+        fields = [fields] if isinstance(fields, str) else fields
 
         setup = await self.__setup_requests(items, taxon)
         scopes = [scopes] if isinstance(scopes, str) else scopes
-        print(f"Number of setup chunks: {len(setup.chunks)}")
 
         url = (
             f"{self._base_url}/query?"

--- a/src/fast_bioservices/biothings/mygene.py
+++ b/src/fast_bioservices/biothings/mygene.py
@@ -67,6 +67,7 @@ class MyGene(BioThings):
 
         setup = await self.__setup_requests(items, taxon)
         scopes = [scopes] if isinstance(scopes, str) else scopes
+        print(f"Number of setup chunks: {len(setup.chunks)}")
 
         url = (
             f"{self._base_url}/query?"

--- a/src/fast_bioservices/biothings/mygene.py
+++ b/src/fast_bioservices/biothings/mygene.py
@@ -84,6 +84,7 @@ class MyGene(BioThings):
         for r in responses:
             results.extend(json.loads(r))
         print(results[:10])
+        exit()
         return results
 
     async def metadata(self):

--- a/src/fast_bioservices/biothings/mygene.py
+++ b/src/fast_bioservices/biothings/mygene.py
@@ -83,8 +83,6 @@ class MyGene(BioThings):
         results: list[dict] = []
         for r in responses:
             results.extend(json.loads(r))
-        print(results[:10])
-        exit()
         return results
 
     async def metadata(self):

--- a/src/fast_bioservices/biothings/mygene.py
+++ b/src/fast_bioservices/biothings/mygene.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import json
-from typing import Iterable, NamedTuple
+from collections.abc import Iterable
+from typing import NamedTuple
 
 from loguru import logger
 

--- a/src/fast_bioservices/biothings/mygene.py
+++ b/src/fast_bioservices/biothings/mygene.py
@@ -78,14 +78,7 @@ class MyGene(BioThings):
         url += f"&scopes={','.join(scopes)}" if scopes else ""
 
         # Iterate through chunks to perform error checking
-        data = []
-        for chunk in setup.chunks:
-            try:
-                as_json = json.dumps({"q": chunk})
-                data.append(as_json)
-            except TypeError as e:  # noqa: PERF203
-                raise TypeError(f"Unable to convert to JSON: {chunk}") from e
-
+        data = [json.dumps({"q": chunk}) for chunk in setup.chunks]
         responses = await self._post(url, data=data, headers={"Content-type": "application/json"})
         results: list[dict] = []
         for r in responses:

--- a/src/fast_bioservices/biothings/mygene.py
+++ b/src/fast_bioservices/biothings/mygene.py
@@ -83,6 +83,7 @@ class MyGene(BioThings):
         results: list[dict] = []
         for r in responses:
             results.extend(json.loads(r))
+        print(results[:10])
         return results
 
     async def metadata(self):

--- a/src/fast_bioservices/biothings/mygene.py
+++ b/src/fast_bioservices/biothings/mygene.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import NamedTuple
+from typing import Iterable, NamedTuple
 
 from loguru import logger
 
@@ -50,7 +50,7 @@ class MyGene(BioThings):
         items: list[str],
         taxon: int | str | Taxon,
         scopes: str | list[str] | None = None,
-        fields: str | list[str] = "all",
+        fields: str | Iterable[str] = ("all",),
         ensembl_only: bool = False,
         entrez_only: bool = False,
     ) -> list[dict]:

--- a/src/fast_bioservices/biothings/mygene.py
+++ b/src/fast_bioservices/biothings/mygene.py
@@ -80,7 +80,8 @@ class MyGene(BioThings):
             f"species={setup.taxon_id}&"
             f"size={self._chunk_size}&"
             f"fields={','.join(fields)}&"
-            f"dotfield=true"
+            "dotfield=true&"
+            "fetch_all=true"
         )
         url += f"&scopes={','.join(scopes)}" if scopes else ""
 

--- a/src/fast_bioservices/fast_http.py
+++ b/src/fast_bioservices/fast_http.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json.decoder
 import logging
 import multiprocessing
 import sys
@@ -181,6 +182,9 @@ class _AsyncHTTPClient:
         except httpx.ConnectError as e:
             logger.critical(f"ConnectError: Failed to establish a connection: {url}")
             raise e from httpx.ConnectError
+        except json.decoder.JSONDecodeError:
+            logger.critical(f"JSONDecodeError: Failed to decode JSON response: {url}")
+            raise e from json.decoder.JSONDecodeError
 
         if log_on_complete:
             if response.extensions.get("from_cache"):

--- a/src/fast_bioservices/fast_http.py
+++ b/src/fast_bioservices/fast_http.py
@@ -98,6 +98,7 @@ class _AsyncHTTPClient:
         else:
             self._transport = transport
         self._client: httpx.AsyncClient = httpx.AsyncClient(transport=self._transport, timeout=180)
+        logger.add("hishel.controller", level="TRACE")
 
         self._semaphore = asyncio.Semaphore(value=5)
         self.__current_requests: int = 0
@@ -177,7 +178,7 @@ class _AsyncHTTPClient:
         self.__current_requests = 0
         self.__total_requests = len(urls)
         headers = headers or {}
-        extensions = extensions or {}
+        extensions = extensions or {"force_cache": True}
         extensions["cache_disabled"] = temp_disable_cache
         self._setup_action()
 

--- a/src/fast_bioservices/fast_http.py
+++ b/src/fast_bioservices/fast_http.py
@@ -182,7 +182,7 @@ class _AsyncHTTPClient:
         except httpx.ConnectError as e:
             logger.critical(f"ConnectError: Failed to establish a connection: {url}")
             raise e from httpx.ConnectError
-        except json.decoder.JSONDecodeError:
+        except json.decoder.JSONDecodeError as e:
             logger.critical(f"JSONDecodeError: Failed to decode JSON response: {url}")
             raise e from json.decoder.JSONDecodeError
 

--- a/src/fast_bioservices/fast_http.py
+++ b/src/fast_bioservices/fast_http.py
@@ -187,10 +187,7 @@ class _AsyncHTTPClient:
             raise e from json.decoder.JSONDecodeError
 
         if log_on_complete:
-            if response.extensions.get("from_cache"):
-                self._log_callback(cached=True)
-            else:
-                self._log_callback(cached=False)
+            self._log_callback(cached=response.extensions.get("from_cache", False))
         return response
 
     def _setup_action(self) -> None:

--- a/src/fast_bioservices/fast_http.py
+++ b/src/fast_bioservices/fast_http.py
@@ -98,7 +98,7 @@ class _AsyncHTTPClient:
         else:
             self._transport = transport
         self._client: httpx.AsyncClient = httpx.AsyncClient(transport=self._transport, timeout=180)
-        logger.add("hishel.controller", level="TRACE")
+        logger.add("hishel.log", level="TRACE", filter="hishel.controller")
 
         self._semaphore = asyncio.Semaphore(value=5)
         self.__current_requests: int = 0

--- a/src/fast_bioservices/pipeline/__init__.py
+++ b/src/fast_bioservices/pipeline/__init__.py
@@ -93,6 +93,7 @@ async def gene_symbol_to_ensembl_and_gene_id(
     symbols = [symbols] if isinstance(symbols, str) else symbols
     data: dict[str, list[str | pd.NA]] = {"gene_symbol": [], "ensembl_gene_id": [], "entrez_gene_id": []}
     for response in await MyGene(cache=cache).query(items=symbols, taxon=taxon, scopes="symbol"):
+        print(response)
         data["gene_symbol"].append(response["query"])
 
         if "notfound" in response:

--- a/src/fast_bioservices/pipeline/__init__.py
+++ b/src/fast_bioservices/pipeline/__init__.py
@@ -106,6 +106,9 @@ async def gene_symbol_to_ensembl_and_gene_id(
         else:
             data["ensembl_gene_id"].append(value)
 
+    print(f"{len(data['gene_symbol'])=}")
+    print(f"{len(data['ensembl_gene_id'])=}")
+    print(f"{len(data['entrez_gene_id'])=}")
     df = pd.DataFrame(data)
     print(df)
     if rerun_if_na and df["ensembl_gene_id"].isna().all() and df["entrez_gene_id"].isna().all():

--- a/src/fast_bioservices/pipeline/__init__.py
+++ b/src/fast_bioservices/pipeline/__init__.py
@@ -45,7 +45,6 @@ async def ensembl_to_gene_id_and_symbol(
 ) -> pd.DataFrame:
     data = []
     results = await MyGene(cache=cache).gene(ids=ids, taxon=taxon)
-    print(len(results))
     for result in results:
         ensembl_data = result.get("ensembl", {})
         ensembl_gene_id = (

--- a/src/fast_bioservices/pipeline/__init__.py
+++ b/src/fast_bioservices/pipeline/__init__.py
@@ -107,11 +107,15 @@ async def gene_symbol_to_ensembl_and_gene_id(
             data["ensembl_gene_id"].append(value)
 
     with open("gene_symbols.txt", "w") as out:
-        out.write("\n".join(data["gene_symbol"]))
+        # Remove NA values
+        clean = [i for i in data["gene_symbol"] if isinstance(i, str)]
+        out.write("\n".join(clean))
     with open("ensembl_gene_ids.txt", "w") as out:
-        out.write("\n".join(data["ensembl_gene_id"]))
+        clean = [i for i in data["ensembl_gene_id"] if isinstance(i, str)]
+        out.write("\n".join(clean))
     with open("entrez_gene_ids.txt", "w") as out:
-        out.write("\n".join(data["entrez_gene_id"]))
+        clean = [i for i in data["entrez_gene_id"] if isinstance(i, str)]
+        out.write("\n".join(clean))
     df = pd.DataFrame(data)
     print(df)
     if rerun_if_na and df["ensembl_gene_id"].isna().all() and df["entrez_gene_id"].isna().all():

--- a/src/fast_bioservices/pipeline/__init__.py
+++ b/src/fast_bioservices/pipeline/__init__.py
@@ -106,9 +106,12 @@ async def gene_symbol_to_ensembl_and_gene_id(
         else:
             data["ensembl_gene_id"].append(value)
 
-    print(f"{len(data['gene_symbol'])=}")
-    print(f"{len(data['ensembl_gene_id'])=}")
-    print(f"{len(data['entrez_gene_id'])=}")
+    with open("gene_symbols.txt", "w") as out:
+        out.write("\n".join(data["gene_symbol"]))
+    with open("ensembl_gene_ids.txt", "w") as out:
+        out.write("\n".join(data["ensembl_gene_id"]))
+    with open("entrez_gene_ids.txt", "w") as out:
+        out.write("\n".join(data["entrez_gene_id"]))
     df = pd.DataFrame(data)
     print(df)
     if rerun_if_na and df["ensembl_gene_id"].isna().all() and df["entrez_gene_id"].isna().all():

--- a/src/fast_bioservices/pipeline/__init__.py
+++ b/src/fast_bioservices/pipeline/__init__.py
@@ -93,7 +93,6 @@ async def gene_symbol_to_ensembl_and_gene_id(
     symbols = [symbols] if isinstance(symbols, str) else symbols
     data: dict[str, list[str | pd.NA]] = {"gene_symbol": [], "ensembl_gene_id": [], "entrez_gene_id": []}
     for response in await MyGene(cache=cache).query(items=symbols, taxon=taxon, scopes="symbol"):
-        print(response)
         data["gene_symbol"].append(response["query"])
 
         if "notfound" in response:
@@ -101,8 +100,11 @@ async def gene_symbol_to_ensembl_and_gene_id(
             data["entrez_gene_id"].append(pd.NA)
             continue
 
-        data["ensembl_gene_id"].append(response.get("ensembl.gene", pd.NA))
-        data["entrez_gene_id"].append(response.get("entrezgene", pd.NA))
+        value = str(response["_id"])
+        if value.isdigit():
+            data["entrez_gene_id"].append(value)
+        else:
+            data["ensembl_gene_id"].append(value)
 
     df = pd.DataFrame(data)
     print(df)

--- a/uv.lock
+++ b/uv.lock
@@ -169,7 +169,7 @@ wheels = [
 
 [[package]]
 name = "fast-bioservices"
-version = "0.3.8"
+version = "0.3.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -196,7 +196,7 @@ requires-dist = [
     { name = "hishel", specifier = ">=0.1.1" },
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "loguru", specifier = ">=0.7.2" },
-    { name = "pandas", specifier = ">=2.0.0" },
+    { name = "pandas", specifier = ">=1.5.3" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
This fixes the URL `field` parameter usage. Previously, the default value (`"all"`), was being split into a list (i.e., `["a", "l", "l"]`). It should be created as a list so `.join` can be used properly to create `["all"]`